### PR TITLE
moved error middleware to bottom and fixed footer and nav in root.js

### DIFF
--- a/app/components/root.jsx
+++ b/app/components/root.jsx
@@ -28,7 +28,7 @@ export default class Root extends Component {
     return (
       <Router>
         <main>
-          <Route component={Nav} />
+          <Nav />
           <Switch>
             <Route path="/" component={Home} exact />
             <Route path="/cart" component={CartTable} exact />
@@ -40,7 +40,7 @@ export default class Root extends Component {
             <Route path="/checkout2" component={CheckoutGuestPay} exact />
             <Route path="/success" component={Success} exact />
           </Switch>
-          <Route component={Footer} />
+          <Footer />
         </main>
       </Router>
     );

--- a/server/index.js
+++ b/server/index.js
@@ -64,15 +64,15 @@ app.use(express.static(path.join(__dirname, '../public')));
 // got to use those routes!
 app.use('/api', require('./api'));
 
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public/index.html'));
+});
+
 // handling errors
 app.use((err, req, res, next) => {
   // this is for testing; so if we don't have tests we can remove it
   if (process.env.NODE_ENV !== 'test') console.error(err.stack);
   res.status(err.status || 500).send(err.message || 'Internal server error');
-});
-
-app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '../public/index.html'));
 });
 
 module.exports = app;


### PR DESCRIPTION
moved error middleware to the bottom of index.js (soon to be retitled express.js) and made the footer and nav just components in root.js instead of routes